### PR TITLE
Changes and fixes

### DIFF
--- a/src/Individual_XP.cpp
+++ b/src/Individual_XP.cpp
@@ -42,9 +42,9 @@ public:
         {
             uint32 rate = data->XPRate;
             if (rate <= 1)
-                CharacterDatabase.PDirectExecute("DELETE FROM `individualxp` WHERE `CharacterGUID` = %u", p->GetGUIDLow());
+                CharacterDatabase.DirectExecute("DELETE FROM `individualxp` WHERE `CharacterGUID` = %u", p->GetGUIDLow());
             else
-                CharacterDatabase.PDirectExecute("REPLACE INTO `individualxp` (`CharacterGUID`, `XPRate`) VALUES (%u, %u);", p->GetGUIDLow(), rate);
+                CharacterDatabase.DirectExecute("REPLACE INTO `individualxp` (`CharacterGUID`, `XPRate`) VALUES (%u, %u);", p->GetGUIDLow(), rate);
         }
     }
 

--- a/src/Individual_XP.cpp
+++ b/src/Individual_XP.cpp
@@ -73,7 +73,7 @@ public:
     {
         if (!*args)
             return false;
-            
+
         Player* me = handler->GetSession()->GetPlayer();
         if (!me)
             return false;

--- a/src/Individual_XP.cpp
+++ b/src/Individual_XP.cpp
@@ -42,9 +42,9 @@ public:
         {
             uint32 rate = data->XPRate;
             if (rate <= 1)
-                CharacterDatabase.DirectExecute("DELETE FROM `individualxp` WHERE `CharacterGUID` = %u", p->GetGUIDLow());
+                CharacterDatabase.DirectPExecute("DELETE FROM `individualxp` WHERE `CharacterGUID` = %u", p->GetGUIDLow());
             else
-                CharacterDatabase.DirectExecute("REPLACE INTO `individualxp` (`CharacterGUID`, `XPRate`) VALUES (%u, %u);", p->GetGUIDLow(), rate);
+                CharacterDatabase.DirectPExecute("REPLACE INTO `individualxp` (`CharacterGUID`, `XPRate`) VALUES (%u, %u);", p->GetGUIDLow(), rate);
         }
     }
 


### PR DESCRIPTION
- Remove double XP log (show all XP in one log message). This should fix gaining XP when at max level.
- Remove/dont save non increased XP rates to DB (XP rate 0 and 1)
- If XP rate is not in DB, dont create one and do nothing on givexp event
- Add override keywords

Was the double XP log intended and desired?
I have not tested these changes. Please test them before merge.